### PR TITLE
fix: Upload issue

### DIFF
--- a/pages/admin/portcos.tsx
+++ b/pages/admin/portcos.tsx
@@ -198,12 +198,13 @@ function Portcos(props) {
               return (
                 <MonospacePreview
                   key={each.id}
+                  itemKey={each.id}
                   onRefresh={async (file) => {
                     const confirm = window.confirm(`Are you sure you want to replace ${each.data.src} with another image? This action is irreversible.`);
                     if (!confirm) {
+                      console.log('Not confirmed');
                       return;
                     }
-
                     const deleteResponse = await onDeleteData({ id: each.id, key });
                     if (!deleteResponse || deleteResponse.error) {
                       setModal({

--- a/system/MonospacePreview.tsx
+++ b/system/MonospacePreview.tsx
@@ -16,16 +16,17 @@ export default function MonospacePreview(props) {
           <span className={styles.right}>
             <input
               type="file"
-              id="template-form-upload-input"
+              id={`refresh-input-${props.itemKey}`}
               style={{ display: 'none' }}
               onChange={(e) => {
                 e.preventDefault();
                 if (e.target.files && e.target.files[0]) {
                   props.onRefresh(e.target.files[0]);
                 }
+                e.target.value = '';
               }}
             />
-            <label htmlFor="template-form-upload-input">
+            <label htmlFor={`refresh-input-${props.itemKey}`}>
               <Replace width="12px" height="12px" />
             </label>
           </span>


### PR DESCRIPTION
Previous breaking behavior: uploading any file will cause the first file in the file list to be replaced by the latest file; clicking on the file uploader will cause a file to get replaced; if you cancel an upload after selecting a file, you won't be able to upload again

Fix: distinguish the IDs of the file uploader and refresher components, clear state per upload.

Current behavior: file uploader successfully uploads file on click, refresher replaces each file (tested with multiple logos).

